### PR TITLE
Feat/next prompt button

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,23 +1,21 @@
 "use client";
 import Sketchpad from "@/components/Sketchpad";
 import { GuessState } from "@/utils/types";
-import { useEffect, useState } from "react";
-import { DRAWING_PROMPTS } from "@/utils/drawing-prompts";
+import { useCallback, useEffect, useState } from "react";
+import { getRandomPrompt } from "@/utils/get-random-prompt";
 
 export default function Home() {
   const [response, setResponse] = useState<string>("");
   const [guessState, setGuessState] = useState<GuessState>(GuessState.Pending);
-  const [currentDrawingPrompt, seCurrentDrawingPrompt] = useState<string>("");
+  const [currentDrawingPrompt, setCurrentDrawingPrompt] = useState<string>("");
   // the image url processing happens entirely in Sketchpad. For now it is discarded after being given to the API. For future reference could save it.
 
-  // Currently DRAWING_PROMPTS is a 100 item static list of prompts 
-  // A future feature could be selecting from prompt categories as well as difficulties. 
-  // Example a easy geography / map / culture question is draw the USA, a hard one would be draw Brunei 
+
   useEffect(() => {
-    const randomPrompt = DRAWING_PROMPTS[Math.floor(Math.random() * DRAWING_PROMPTS.length)];
-    seCurrentDrawingPrompt(randomPrompt);
+    setCurrentDrawingPrompt(getRandomPrompt())
   }, [])
 
+ 
   
   // Visual Indicator for guess correctness, this is a placeholder for a more advanced scoring system
   const borderColorMap = {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,14 @@
 "use client";
 import Sketchpad from "@/components/Sketchpad";
-import { GuessState } from "@/utils/types";
-import { useEffect, useState } from "react";
+import { GuessState, SketchpadRef } from "@/utils/types";
+import { useEffect, useState, useRef } from "react";
 import { getRandomPrompt } from "@/utils/get-random-prompt";
 
 export default function Home() {
   const [response, setResponse] = useState<string>("");
   const [guessState, setGuessState] = useState<GuessState>(GuessState.Pending);
   const [currentDrawingPrompt, setCurrentDrawingPrompt] = useState<string>("");
+  const sketchpadRef = useRef<SketchpadRef>(null);
   // the image url processing happens entirely in Sketchpad. For now it is discarded after being given to the API. For future reference could save it.
 
   // Gets random prompt on page load
@@ -19,6 +20,9 @@ export default function Home() {
     setCurrentDrawingPrompt(getRandomPrompt());
     setGuessState(GuessState.Pending);
     setResponse("");
+    if (sketchpadRef.current) {
+      sketchpadRef.current.clearCanvas();
+    }
   };
 
   // Visual Indicator for guess correctness, this is a placeholder for a more advanced scoring system
@@ -33,6 +37,7 @@ export default function Home() {
       <h1 className="text-4xl">AI Pictionary</h1>
       <h2 className="text-3xl">Draw a {currentDrawingPrompt}</h2>
       <Sketchpad
+        ref={sketchpadRef}
         setResponse={setResponse}
         setGuessState={setGuessState}
         currentDrawingPrompt={currentDrawingPrompt}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,6 +34,7 @@ export default function Home() {
       <div className={`border-2 px-120 py-20 rounded-2xl mt-10 ${borderColorMap[guessState]}`}>
         {response}
       </div>
+      <button className="bg-blue-400 text-white px-10 py-3 rounded-xl text-2xl shadow-lg hover:cursor-pointer transition hover:scale-110">Next Prompt</button>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import Sketchpad from "@/components/Sketchpad";
 import { GuessState } from "@/utils/types";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { getRandomPrompt } from "@/utils/get-random-prompt";
 
 export default function Home() {
@@ -10,13 +10,17 @@ export default function Home() {
   const [currentDrawingPrompt, setCurrentDrawingPrompt] = useState<string>("");
   // the image url processing happens entirely in Sketchpad. For now it is discarded after being given to the API. For future reference could save it.
 
-
-  // Gets random prompt on page load 
+  // Gets random prompt on page load
   useEffect(() => {
-    setCurrentDrawingPrompt(getRandomPrompt())
-  }, [])
+    setCurrentDrawingPrompt(getRandomPrompt());
+  }, []);
 
- 
+  const handleNextPrompt = () => {
+    setCurrentDrawingPrompt(getRandomPrompt());
+    setGuessState(GuessState.Pending);
+    setResponse("");
+  };
+
   // Visual Indicator for guess correctness, this is a placeholder for a more advanced scoring system
   const borderColorMap = {
     [GuessState.Pending]: "border-black",
@@ -28,11 +32,20 @@ export default function Home() {
     <div className="flex items-center justify-center flex-col gap-4 container mx-auto">
       <h1 className="text-4xl">AI Pictionary</h1>
       <h2 className="text-3xl">Draw a {currentDrawingPrompt}</h2>
-      <Sketchpad setResponse={setResponse} setGuessState={setGuessState} currentDrawingPrompt={currentDrawingPrompt}></Sketchpad>
+      <Sketchpad
+        setResponse={setResponse}
+        setGuessState={setGuessState}
+        currentDrawingPrompt={currentDrawingPrompt}
+      ></Sketchpad>
       <div className={`border-2 px-120 py-20 rounded-2xl mt-10 ${borderColorMap[guessState]}`}>
         {response}
       </div>
-      <button className="bg-blue-400 text-white px-10 py-3 rounded-xl text-2xl shadow-lg hover:cursor-pointer transition hover:scale-110">Next Prompt</button>
+      <button
+        onClick={handleNextPrompt}
+        className="bg-blue-400 text-white px-10 py-3 rounded-xl text-2xl shadow-lg hover:cursor-pointer transition hover:scale-110"
+      >
+        Next Prompt
+      </button>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,12 +11,12 @@ export default function Home() {
   // the image url processing happens entirely in Sketchpad. For now it is discarded after being given to the API. For future reference could save it.
 
 
+  // Gets random prompt on page load 
   useEffect(() => {
     setCurrentDrawingPrompt(getRandomPrompt())
   }, [])
 
  
-  
   // Visual Indicator for guess correctness, this is a placeholder for a more advanced scoring system
   const borderColorMap = {
     [GuessState.Pending]: "border-black",

--- a/src/components/Sketchpad.tsx
+++ b/src/components/Sketchpad.tsx
@@ -1,11 +1,22 @@
-import { useRef } from "react";
+import { useRef, forwardRef, useImperativeHandle, type Ref } from "react";
 import { ReactSketchCanvas, ReactSketchCanvasRef } from "react-sketch-canvas";
-import { GuessState, SketchpadProps } from "@/utils/types";
+import { GuessState, SketchpadProps, SketchpadRef } from "@/utils/types";
 import { checkGuess } from "@/utils/check-guess";
-export default function Sketchpad({ setResponse, setGuessState, currentDrawingPrompt }: SketchpadProps) {
+function Sketchpad(
+  { setResponse, setGuessState, currentDrawingPrompt }: SketchpadProps,
+  ref: Ref<SketchpadRef>
+) {
   const canvasRef = useRef<ReactSketchCanvasRef>(null);
 
-  // Currently this function as well as the API function is very very janky. This is Proof of Concept Code 
+  useImperativeHandle(ref, () => ({
+    clearCanvas: () => {
+      if (canvasRef.current) {
+        canvasRef.current.clearCanvas();
+      }
+    },
+  }));
+
+  // Currently this function as well as the API function is very very janky. This is Proof of Concept Code
   // The core code itself is fine however there are no guard rails and the code is a nightmare to debug
   // To-do: write tests
   async function handleSubmit() {
@@ -14,20 +25,20 @@ export default function Sketchpad({ setResponse, setGuessState, currentDrawingPr
       return;
     }
 
-    // Gemini API only accepts rawBase64Data not DataURI 
+    // Gemini API only accepts rawBase64Data not DataURI
     const fullDataURI = await canvasRef.current.exportImage("png");
-    const rawBase64Data = fullDataURI.split(",")[1]; 
+    const rawBase64Data = fullDataURI.split(",")[1];
 
     try {
-      // API Call 
+      // API Call
       const response = await fetch("http://localhost:3000/api/generate-response", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ image: rawBase64Data }),
       });
-      
-      // To-Do : More Robust Error Handling, write tests for this function. 
-      // Better idea is to separate this try catch block into its own function 
+
+      // To-Do : More Robust Error Handling, write tests for this function.
+      // Better idea is to separate this try catch block into its own function
       if (!response.ok) {
         throw new Error(`API Error: ${response.status} `);
       }
@@ -35,14 +46,12 @@ export default function Sketchpad({ setResponse, setGuessState, currentDrawingPr
       const result = await response.json();
       setResponse(result.response);
 
-      // Guess Check 
+      // Guess Check
       if (checkGuess(result.response, currentDrawingPrompt)) {
         setGuessState(GuessState.Correct);
       } else {
         setGuessState(GuessState.Incorrect);
       }
-      
-
     } catch (error) {
       console.error(error);
     }
@@ -66,3 +75,5 @@ export default function Sketchpad({ setResponse, setGuessState, currentDrawingPr
     </>
   );
 }
+
+export default forwardRef<SketchpadRef, SketchpadProps>(Sketchpad);

--- a/src/components/Sketchpad.tsx
+++ b/src/components/Sketchpad.tsx
@@ -8,6 +8,7 @@ function Sketchpad(
 ) {
   const canvasRef = useRef<ReactSketchCanvasRef>(null);
 
+  // For functions that other components / parent need 
   useImperativeHandle(ref, () => ({
     clearCanvas: () => {
       if (canvasRef.current) {

--- a/src/utils/get-random-prompt.ts
+++ b/src/utils/get-random-prompt.ts
@@ -1,0 +1,14 @@
+/**
+ * Gets a random prompt from the list of provided random prompts
+ * @returns {string} Returns a string which is the prompt 
+ * Currently DRAWING_PROMPTS is a 100 item static list of prompts 
+ * A future feature could be selecting from prompt categories as well as difficulties. 
+ * Example a easy geography / map / culture question is draw the USA, a hard one would be draw Brunei 
+*/ 
+
+import { DRAWING_PROMPTS } from "@/utils/drawing-prompts";
+
+export const getRandomPrompt = (): string => {
+  const randomPrompt = DRAWING_PROMPTS[Math.floor(Math.random() * DRAWING_PROMPTS.length)];
+  return randomPrompt;
+};

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -4,6 +4,10 @@ export interface SketchpadProps {
   currentDrawingPrompt: string;
 }
 
+export interface SketchpadRef {
+  clearCanvas: () => void;
+}
+
 export enum GuessState {
   Pending = "PENDING",
   Correct = "CORRECT",


### PR DESCRIPTION
## Summary - 
This PR adds a next prompt button that selects a new random prompt and also clears the canvas

## Preview - 
![feat-next-prompt-button](https://github.com/user-attachments/assets/35765010-50af-4931-a883-a6372883556f)

## Closes #15 