### PR TITLE
Feat/turn cycle

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,3 @@
 {
-  "cSpell.words": [
-    "genai"
-  ]
+  "cSpell.words": ["genai", "SHOWINGRESULT"]
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,6 +27,19 @@ export default function Home() {
     }
   };
 
+  const turnCycleMap = {
+    [TurnCycleState.Drawing]: <div></div>,
+    [TurnCycleState.ShowingResult]: (
+      <TurnResultSection
+        response={response}
+        guessState={guessState}
+        handleNextPrompt={handleNextPrompt}
+      ></TurnResultSection>
+    ),
+    [TurnCycleState.Loading]: <div>Loading...</div>,
+    [TurnCycleState.Error]: <div>Error</div>,
+  };
+
   return (
     <div className="flex items-center justify-center flex-col gap-4 container mx-auto">
       <h1 className="text-4xl">AI Pictionary</h1>
@@ -35,13 +48,10 @@ export default function Home() {
         ref={sketchpadRef}
         setResponse={setResponse}
         setGuessState={setGuessState}
+        setTurnCycleState={setTurnCycleState}
         currentDrawingPrompt={currentDrawingPrompt}
       ></Sketchpad>
-      <TurnResultSection
-        response={response}
-        guessState={guessState}
-        handleNextPrompt={handleNextPrompt}
-      ></TurnResultSection>
+      {turnCycleMap[turnCycleState]}
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -52,6 +52,9 @@ export default function Home() {
         setTurnCycleState={setTurnCycleState}
         currentDrawingPrompt={currentDrawingPrompt}
       ></Sketchpad>
+
+      {/* Results Section  */}
+      {/* TODO: Qol improvement would be auto scrolling to the results section */}
       {turnCycleMap[turnCycleState]}
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,6 +21,7 @@ export default function Home() {
   const handleNextPrompt = () => {
     setCurrentDrawingPrompt(getRandomPrompt());
     setGuessState(GuessState.Pending);
+    setTurnCycleState(TurnCycleState.Drawing);
     setResponse("");
     if (sketchpadRef.current) {
       sketchpadRef.current.clearCanvas();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import Sketchpad from "@/components/Sketchpad";
+import TurnResultSection from "@/components/TurnResultSection";
 import { GuessState, SketchpadRef, TurnCycleState } from "@/utils/types";
 import { useEffect, useState, useRef } from "react";
 import { getRandomPrompt } from "@/utils/get-random-prompt";
@@ -26,13 +27,6 @@ export default function Home() {
     }
   };
 
-  // Visual Indicator for guess correctness, this is a placeholder for a more advanced scoring system
-  const borderColorMap = {
-    [GuessState.Pending]: "border-black",
-    [GuessState.Correct]: "border-emerald-500",
-    [GuessState.Incorrect]: "border-red-500",
-  };
-
   return (
     <div className="flex items-center justify-center flex-col gap-4 container mx-auto">
       <h1 className="text-4xl">AI Pictionary</h1>
@@ -43,15 +37,11 @@ export default function Home() {
         setGuessState={setGuessState}
         currentDrawingPrompt={currentDrawingPrompt}
       ></Sketchpad>
-      <div className={`border-2 px-120 py-20 rounded-2xl mt-10 ${borderColorMap[guessState]}`}>
-        {response}
-      </div>
-      <button
-        onClick={handleNextPrompt}
-        className="bg-blue-400 text-white px-10 py-3 rounded-xl text-2xl shadow-lg hover:cursor-pointer transition hover:scale-110"
-      >
-        Next Prompt
-      </button>
+      <TurnResultSection
+        response={response}
+        guessState={guessState}
+        handleNextPrompt={handleNextPrompt}
+      ></TurnResultSection>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 import Sketchpad from "@/components/Sketchpad";
-import { GuessState, SketchpadRef } from "@/utils/types";
+import { GuessState, SketchpadRef, TurnCycleState } from "@/utils/types";
 import { useEffect, useState, useRef } from "react";
 import { getRandomPrompt } from "@/utils/get-random-prompt";
 
 export default function Home() {
   const [response, setResponse] = useState<string>("");
   const [guessState, setGuessState] = useState<GuessState>(GuessState.Pending);
+  const [turnCycleState, setTurnCycleState] = useState<TurnCycleState>(TurnCycleState.Drawing);
   const [currentDrawingPrompt, setCurrentDrawingPrompt] = useState<string>("");
   const sketchpadRef = useRef<SketchpadRef>(null);
   // the image url processing happens entirely in Sketchpad. For now it is discarded after being given to the API. For future reference could save it.

--- a/src/components/Sketchpad.tsx
+++ b/src/components/Sketchpad.tsx
@@ -34,7 +34,7 @@ function Sketchpad(
       console.error("Canvas ref is not available yet");
       return;
     }
-
+    setTurnCycleState(TurnCycleState.Loading);
     // Gemini API only accepts rawBase64Data not DataURI
     const fullDataURI = await canvasRef.current.exportImage("png");
     const rawBase64Data = fullDataURI.split(",")[1];

--- a/src/components/Sketchpad.tsx
+++ b/src/components/Sketchpad.tsx
@@ -1,10 +1,10 @@
 import { useRef, forwardRef, useImperativeHandle, type Ref } from "react";
 import { ReactSketchCanvas, ReactSketchCanvasRef } from "react-sketch-canvas";
-import { GuessState, SketchpadProps, SketchpadRef } from "@/utils/types";
+import { GuessState, SketchpadProps, SketchpadRef, TurnCycleState } from "@/utils/types";
 import { checkGuess } from "@/utils/check-guess";
 import { Trash2 } from "lucide-react";
 function Sketchpad(
-  { setResponse, setGuessState, currentDrawingPrompt }: SketchpadProps,
+  { setResponse, setGuessState, setTurnCycleState, currentDrawingPrompt }: SketchpadProps,
   ref: Ref<SketchpadRef>
 ) {
   const canvasRef = useRef<ReactSketchCanvasRef>(null);
@@ -41,6 +41,7 @@ function Sketchpad(
 
     try {
       // API Call
+
       const response = await fetch("http://localhost:3000/api/generate-response", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -54,7 +55,9 @@ function Sketchpad(
       }
 
       const result = await response.json();
+
       setResponse(result.response);
+      setTurnCycleState(TurnCycleState.ShowingResult);
 
       // Guess Check
       if (checkGuess(result.response, currentDrawingPrompt)) {

--- a/src/components/TurnResultSection.tsx
+++ b/src/components/TurnResultSection.tsx
@@ -1,0 +1,28 @@
+import { TurnResultProps, GuessState } from "@/utils/types";
+
+export default function TurnResultSection({
+  response,
+  handleNextPrompt,
+  guessState,
+}: TurnResultProps) {
+  // Visual Indicator for guess correctness, this is a placeholder for a more advanced scoring system
+  const borderColorMap = {
+    [GuessState.Pending]: "border-black",
+    [GuessState.Correct]: "border-emerald-500",
+    [GuessState.Incorrect]: "border-red-500",
+  };
+
+  return (
+    <>
+      <div className={`border-2 px-120 py-20 rounded-2xl mt-10 ${borderColorMap[guessState]}`}>
+        {response}
+      </div>
+      <button
+        onClick={handleNextPrompt}
+        className="bg-blue-400 text-white px-10 py-3 rounded-xl text-2xl shadow-lg hover:cursor-pointer transition hover:scale-110"
+      >
+        Next Prompt
+      </button>
+    </>
+  );
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -2,6 +2,7 @@ export interface SketchpadProps {
   setResponse: (response: string) => void;
   setGuessState: (guess: GuessState) => void;
   currentDrawingPrompt: string;
+  setTurnCycleState: (turnCycle: TurnCycleState) => void;
 }
 
 export interface SketchpadRef {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -22,3 +22,9 @@ export enum TurnCycleState {
   ShowingResult = "SHOWINGRESULT",
   Error = "ERROR",
 }
+
+export interface TurnResultProps {
+  handleNextPrompt: () => void;
+  response: string;
+  guessState: GuessState;
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -13,3 +13,12 @@ export enum GuessState {
   Correct = "CORRECT",
   Incorrect = "INCORRECT",
 }
+
+// idk if it is honestly necessary to have another enum for turn cycle.
+// Possible refactor to combine guess state and turn cycle?
+export enum TurnCycleState {
+  Drawing = "DRAWING",
+  Loading = "LOADING",
+  ShowingResult = "SHOWINGRESULT",
+  Error = "ERROR",
+}


### PR DESCRIPTION
## Summary 
This feature hides the results section ( the next prompt and AI response) when the user is drawing. When the user submits, the section is shown. 

## Changes
- Added map to toggle between turn cycle states
- Refactored the results box and next prompt button into its own component
- Added states for error and loading

## Preview

![feat-turn-cycle](https://github.com/user-attachments/assets/34d63406-6bb1-4bc9-8673-eaf71094b49e)

## Closes #23 