### PR TITLE
Feat/results page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { GuessState, SketchpadRef, TurnCycleState, GameState } from "@/utils/typ
 import { useEffect, useState, useRef } from "react";
 import { getRandomPrompt } from "@/utils/get-random-prompt";
 import Lobby from "@/components/Lobby";
+import GameResults from "@/components/GameResults";
 
 export default function Home() {
   const [response, setResponse] = useState<string>("");
@@ -75,7 +76,7 @@ export default function Home() {
         {turnCycleMap[turnCycleState]}
       </div>
     ),
-    [GameState.Results]: <div>Game Over!</div>,
+    [GameState.Results]: <GameResults></GameResults>,
   };
 
   return gameStateMap[gameState];

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,6 +15,7 @@ export default function Home() {
   const [currentDrawingPrompt, setCurrentDrawingPrompt] = useState<string>("");
   const sketchpadRef = useRef<SketchpadRef>(null);
   const [roundNumber, setRoundNumber] = useState(1);
+  const [correctGuesses, setCorrectGuesses] = useState(0);
 
   // the image url processing happens entirely in Sketchpad. For now it is discarded after being given to the API. For future reference could save it.
 
@@ -69,6 +70,8 @@ export default function Home() {
           setGuessState={setGuessState}
           setTurnCycleState={setTurnCycleState}
           currentDrawingPrompt={currentDrawingPrompt}
+          setCorrectGuesses={setCorrectGuesses}
+          correctGuesses={correctGuesses}
         ></Sketchpad>
 
         {/* Results Section  */}
@@ -77,7 +80,11 @@ export default function Home() {
       </div>
     ),
     [GameState.Results]: (
-      <GameResults setGameState={setGameState} setRoundNumber={setRoundNumber}></GameResults>
+      <GameResults
+        setGameState={setGameState}
+        setRoundNumber={setRoundNumber}
+        correctGuesses={correctGuesses}
+      ></GameResults>
     ),
   };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -84,6 +84,7 @@ export default function Home() {
         setGameState={setGameState}
         setRoundNumber={setRoundNumber}
         correctGuesses={correctGuesses}
+        setCorrectGuesses={setCorrectGuesses}
       ></GameResults>
     ),
   };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -76,7 +76,9 @@ export default function Home() {
         {turnCycleMap[turnCycleState]}
       </div>
     ),
-    [GameState.Results]: <GameResults></GameResults>,
+    [GameState.Results]: (
+      <GameResults setGameState={setGameState} setRoundNumber={setRoundNumber}></GameResults>
+    ),
   };
 
   return gameStateMap[gameState];

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,8 @@ export default function Home() {
   const [turnCycleState, setTurnCycleState] = useState<TurnCycleState>(TurnCycleState.Drawing);
   const [currentDrawingPrompt, setCurrentDrawingPrompt] = useState<string>("");
   const sketchpadRef = useRef<SketchpadRef>(null);
+  const [roundNumber, setRoundNumber] = useState(1);
+
   // the image url processing happens entirely in Sketchpad. For now it is discarded after being given to the API. For future reference could save it.
 
   // Gets random prompt on page load
@@ -28,6 +30,14 @@ export default function Home() {
     if (sketchpadRef.current) {
       sketchpadRef.current.clearCanvas();
     }
+
+    // Round Check
+    const nextRound = roundNumber + 1;
+    setRoundNumber(nextRound);
+    if (nextRound > 5) {
+      console.log("end Game!!");
+      setGameState(GameState.Results);
+    }
   };
 
   const turnCycleMap = {
@@ -37,6 +47,9 @@ export default function Home() {
         response={response}
         guessState={guessState}
         handleNextPrompt={handleNextPrompt}
+        setGameState={setGameState}
+        roundNumber={roundNumber}
+        setRoundNumber={setRoundNumber}
       ></TurnResultSection>
     ),
     [TurnCycleState.Loading]: <div>Loading...</div>,
@@ -62,7 +75,7 @@ export default function Home() {
         {turnCycleMap[turnCycleState]}
       </div>
     ),
-    [GameState.Results]: <div></div>,
+    [GameState.Results]: <div>Game Over!</div>,
   };
 
   return gameStateMap[gameState];

--- a/src/components/GameResults.tsx
+++ b/src/components/GameResults.tsx
@@ -1,0 +1,11 @@
+export default function GameResults() {
+  return (
+    <main className="container mx-auto flex flex-col items-center gap-10 justify-center pt-40">
+      <h1 className="text-5xl">Results</h1>
+      <h2 className="text-4xl">You got __ out of ___ prompts right!</h2>
+      <button className="bg-blue-400 text-white px-10 py-3 rounded-xl text-2xl shadow-lg hover:cursor-pointer transition hover:scale-110">
+        Play Again
+      </button>
+    </main>
+  );
+}

--- a/src/components/GameResults.tsx
+++ b/src/components/GameResults.tsx
@@ -4,10 +4,12 @@ export default function GameResults({
   setGameState,
   setRoundNumber,
   correctGuesses,
+  setCorrectGuesses,
 }: GameResultsProps) {
   const handlePlayAgain = () => {
     setGameState(GameState.Lobby);
     setRoundNumber(1);
+    setCorrectGuesses(0);
   };
   return (
     <main className="container mx-auto flex flex-col items-center gap-10 justify-center pt-40">

--- a/src/components/GameResults.tsx
+++ b/src/components/GameResults.tsx
@@ -1,6 +1,10 @@
 import { GameResultsProps, GameState } from "@/utils/types";
 
-export default function GameResults({ setGameState, setRoundNumber }: GameResultsProps) {
+export default function GameResults({
+  setGameState,
+  setRoundNumber,
+  correctGuesses,
+}: GameResultsProps) {
   const handlePlayAgain = () => {
     setGameState(GameState.Lobby);
     setRoundNumber(1);
@@ -8,7 +12,7 @@ export default function GameResults({ setGameState, setRoundNumber }: GameResult
   return (
     <main className="container mx-auto flex flex-col items-center gap-10 justify-center pt-40">
       <h1 className="text-5xl">Results</h1>
-      <h2 className="text-4xl">You got __ out of ___ prompts right!</h2>
+      <h2 className="text-4xl">You got {correctGuesses} out of 5 prompts right!</h2>
       <button
         onClick={handlePlayAgain}
         className="bg-blue-400 text-white px-10 py-3 rounded-xl text-2xl shadow-lg hover:cursor-pointer transition hover:scale-110"

--- a/src/components/GameResults.tsx
+++ b/src/components/GameResults.tsx
@@ -1,9 +1,18 @@
-export default function GameResults() {
+import { GameResultsProps, GameState } from "@/utils/types";
+
+export default function GameResults({ setGameState, setRoundNumber }: GameResultsProps) {
+  const handlePlayAgain = () => {
+    setGameState(GameState.Lobby);
+    setRoundNumber(1);
+  };
   return (
     <main className="container mx-auto flex flex-col items-center gap-10 justify-center pt-40">
       <h1 className="text-5xl">Results</h1>
       <h2 className="text-4xl">You got __ out of ___ prompts right!</h2>
-      <button className="bg-blue-400 text-white px-10 py-3 rounded-xl text-2xl shadow-lg hover:cursor-pointer transition hover:scale-110">
+      <button
+        onClick={handlePlayAgain}
+        className="bg-blue-400 text-white px-10 py-3 rounded-xl text-2xl shadow-lg hover:cursor-pointer transition hover:scale-110"
+      >
         Play Again
       </button>
     </main>

--- a/src/components/Sketchpad.tsx
+++ b/src/components/Sketchpad.tsx
@@ -4,7 +4,14 @@ import { GuessState, SketchpadProps, SketchpadRef, TurnCycleState } from "@/util
 import { checkGuess } from "@/utils/check-guess";
 import { Trash2 } from "lucide-react";
 function Sketchpad(
-  { setResponse, setGuessState, setTurnCycleState, currentDrawingPrompt }: SketchpadProps,
+  {
+    setResponse,
+    setGuessState,
+    setTurnCycleState,
+    currentDrawingPrompt,
+    setCorrectGuesses,
+    correctGuesses,
+  }: SketchpadProps,
   ref: Ref<SketchpadRef>
 ) {
   const canvasRef = useRef<ReactSketchCanvasRef>(null);
@@ -62,6 +69,8 @@ function Sketchpad(
       // Guess Check
       if (checkGuess(result.response, currentDrawingPrompt)) {
         setGuessState(GuessState.Correct);
+        const newCorrectGuesses = correctGuesses + 1;
+        setCorrectGuesses(newCorrectGuesses);
       } else {
         setGuessState(GuessState.Incorrect);
       }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,5 +1,3 @@
-import { LargeNumberLike } from "crypto";
-
 export interface SketchpadProps {
   setResponse: (response: string) => void;
   setGuessState: (guess: GuessState) => void;
@@ -43,4 +41,9 @@ export interface TurnResultProps {
 
 export interface LobbyProps {
   setGameState: (gameState: GameState) => void;
+}
+
+export interface GameResultsProps {
+  setGameState: (gameState: GameState) => void;
+  setRoundNumber: (roundNumber: number) => void;
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -49,4 +49,5 @@ export interface GameResultsProps {
   setGameState: (gameState: GameState) => void;
   setRoundNumber: (roundNumber: number) => void;
   correctGuesses: number;
+  setCorrectGuesses: (correctGuesses: number) => void;
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,3 +1,5 @@
+import { LargeNumberLike } from "crypto";
+
 export interface SketchpadProps {
   setResponse: (response: string) => void;
   setGuessState: (guess: GuessState) => void;
@@ -34,6 +36,9 @@ export interface TurnResultProps {
   handleNextPrompt: () => void;
   response: string;
   guessState: GuessState;
+  setGameState: (gameState: GameState) => void;
+  roundNumber: number;
+  setRoundNumber: (roundNumber: number) => void;
 }
 
 export interface LobbyProps {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -3,6 +3,8 @@ export interface SketchpadProps {
   setGuessState: (guess: GuessState) => void;
   currentDrawingPrompt: string;
   setTurnCycleState: (turnCycle: TurnCycleState) => void;
+  setCorrectGuesses: (correctGuesses: number) => void;
+  correctGuesses: number;
 }
 
 export interface SketchpadRef {
@@ -46,4 +48,5 @@ export interface LobbyProps {
 export interface GameResultsProps {
   setGameState: (gameState: GameState) => void;
   setRoundNumber: (roundNumber: number) => void;
+  correctGuesses: number;
 }


### PR DESCRIPTION
## Summary
This PR adds a Results / End Screen for the Game

## Changes
- Added results screen component with score and play again button
- State management for round and correct guess counts 
- Added interface for results 

## Preview
![feat-results-page](https://github.com/user-attachments/assets/de92cb8d-76b2-41ec-8385-7294336663a9)


## Closes #22 