### PR TITLE
Refactor/componentize core game logic

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,59 +1,26 @@
 "use client";
-import Sketchpad from "@/components/Sketchpad";
-import TurnResultSection from "@/components/TurnResultSection";
-import { SketchpadRef, TurnCycleState, GameState } from "@/utils/types";
-import { useEffect, useRef } from "react";
+
+import { GameState } from "@/utils/types";
+import { useEffect } from "react";
 import { getRandomPrompt } from "@/utils/get-random-prompt";
 import Lobby from "@/components/Lobby";
 import GameResults from "@/components/GameResults";
 import { useGameStore } from "@/store/gameStore";
+import Game from "@/components/Game";
 
 export default function Home() {
   const gameState = useGameStore((state) => state.gameState);
-  const turnCycleState = useGameStore((state) => state.turnCycleState);
-  const currentDrawingPrompt = useGameStore((state) => state.currentDrawingPrompt);
   const setCurrentDrawingPrompt = useGameStore((state) => state.setCurrentDrawingPrompt);
-  const sketchpadRef = useRef<SketchpadRef>(null);
-  const handleNextPrompt = useGameStore((state) => state.handleNextPrompt);
-
-  // the image url processing happens entirely in Sketchpad. For now it is discarded after being given to the API. For future reference could save it.
 
   // Gets random prompt on page load
   useEffect(() => {
     setCurrentDrawingPrompt(getRandomPrompt());
   }, [setCurrentDrawingPrompt]);
 
-  const onNextPromptClick = () => {
-    if (sketchpadRef.current) {
-      sketchpadRef.current.clearCanvas();
-    }
-    handleNextPrompt();
-  };
-
-  const turnCycleMap = {
-    [TurnCycleState.Drawing]: <div></div>,
-    [TurnCycleState.ShowingResult]: (
-      <TurnResultSection onNextPromptClick={onNextPromptClick}></TurnResultSection>
-    ),
-    [TurnCycleState.Loading]: <div>Loading...</div>,
-    [TurnCycleState.Error]: <div>Error</div>,
-  };
-
   const gameStateMap = {
     [GameState.Lobby]: <Lobby></Lobby>,
     // TODO: Refactor Core Game into its own Component
-    [GameState.Game]: (
-      <div className="flex items-center justify-center flex-col gap-4 container mx-auto py-10">
-        <h1 className="text-5xl" aria-label="prompt">
-          Draw a {currentDrawingPrompt}
-        </h1>
-        <Sketchpad ref={sketchpadRef}></Sketchpad>
-
-        {/* Results Section  */}
-        {/* TODO: Qol improvement would be auto scrolling to the results section */}
-        {turnCycleMap[turnCycleState]}
-      </div>
-    ),
+    [GameState.Game]: <Game></Game>,
     [GameState.Results]: <GameResults></GameResults>,
   };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,9 +3,9 @@
 import { GameState } from "@/utils/types";
 import { useEffect } from "react";
 import { getRandomPrompt } from "@/utils/get-random-prompt";
+import { useGameStore } from "@/store/gameStore";
 import Lobby from "@/components/Lobby";
 import GameResults from "@/components/GameResults";
-import { useGameStore } from "@/store/gameStore";
 import Game from "@/components/Game";
 
 export default function Home() {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,7 +19,6 @@ export default function Home() {
 
   const gameStateMap = {
     [GameState.Lobby]: <Lobby></Lobby>,
-    // TODO: Refactor Core Game into its own Component
     [GameState.Game]: <Game></Game>,
     [GameState.Results]: <GameResults></GameResults>,
   };

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -1,0 +1,43 @@
+import { useGameStore } from "@/store/gameStore";
+import { useRef } from "react";
+import TurnResultSection from "@/components/TurnResultSection";
+import Sketchpad from "@/components/Sketchpad";
+import { SketchpadRef, TurnCycleState } from "@/utils/types";
+
+export default function Game() {
+  const turnCycleState = useGameStore((state) => state.turnCycleState);
+  const currentDrawingPrompt = useGameStore((state) => state.currentDrawingPrompt);
+  const sketchpadRef = useRef<SketchpadRef>(null);
+  const handleNextPrompt = useGameStore((state) => state.handleNextPrompt);
+
+  // the image url processing happens entirely in Sketchpad. For now it is discarded after being given to the API. For future reference could save it.
+  const onNextPromptClick = () => {
+    if (sketchpadRef.current) {
+      sketchpadRef.current.clearCanvas();
+    }
+    handleNextPrompt();
+  };
+
+  const turnCycleMap = {
+    [TurnCycleState.Drawing]: <div></div>,
+    [TurnCycleState.ShowingResult]: (
+      <TurnResultSection onNextPromptClick={onNextPromptClick}></TurnResultSection>
+    ),
+    [TurnCycleState.Loading]: <div>Loading...</div>,
+    [TurnCycleState.Error]: <div>Error</div>,
+  };
+  return (
+    <>
+      <div className="flex items-center justify-center flex-col gap-4 container mx-auto py-10">
+        <h1 className="text-5xl" aria-label="prompt">
+          Draw a {currentDrawingPrompt}
+        </h1>
+        <Sketchpad ref={sketchpadRef}></Sketchpad>
+
+        {/* Results Section  */}
+        {/* TODO: Qol improvement would be auto scrolling to the results section */}
+        {turnCycleMap[turnCycleState]}
+      </div>
+    </>
+  );
+}

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -1,8 +1,8 @@
 import { useGameStore } from "@/store/gameStore";
 import { useRef } from "react";
+import { SketchpadRef, TurnCycleState } from "@/utils/types";
 import TurnResultSection from "@/components/TurnResultSection";
 import Sketchpad from "@/components/Sketchpad";
-import { SketchpadRef, TurnCycleState } from "@/utils/types";
 
 export default function Game() {
   const turnCycleState = useGameStore((state) => state.turnCycleState);

--- a/src/components/GameResults.tsx
+++ b/src/components/GameResults.tsx
@@ -7,6 +7,7 @@ export default function GameResults() {
   const correctGuesses = useGameStore((state) => state.correctGuesses);
   const setCorrectGuesses = useGameStore((state) => state.setCorrectGuesses);
 
+  // TODO: Could move this to game store
   const handlePlayAgain = () => {
     setGameState(GameState.Lobby);
     setRoundNumber(1);

--- a/src/components/Sketchpad.tsx
+++ b/src/components/Sketchpad.tsx
@@ -4,6 +4,7 @@ import { GuessState, SketchpadRef, TurnCycleState } from "@/utils/types";
 import { checkGuess } from "@/utils/check-guess";
 import { Trash2 } from "lucide-react";
 import { useGameStore } from "@/store/gameStore";
+
 function Sketchpad(_: unknown, ref: Ref<SketchpadRef>) {
   const canvasRef = useRef<ReactSketchCanvasRef>(null);
   const setTurnCycleState = useGameStore((state) => state.setTurnCycleState);


### PR DESCRIPTION
## Summary

This PR refactors and moves the core game loop logic to a separate component 

## Reflection 

Honestly this was a really satisfying refactor. Took maybe 15 minutes just me dropping the entire component logic from my map to a separate component and then moving around imports and moving all my props with Zustand. Zustand as well as my integration tests really made this refactor painless. Very happy how clean my page.tsx is now. 

## Closes #40 